### PR TITLE
Add version update libs

### DIFF
--- a/.github/workflows/houdocker_autobuild.yml
+++ b/.github/workflows/houdocker_autobuild.yml
@@ -68,27 +68,27 @@ jobs:
           pytest tests/build/
           echo "status=success" >> $GITHUB_OUTPUT
 
-  hython_test:
-    needs: pingtest
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_USER: ${{secrets.DOCKER_USER}}
-      DOCKER_SECRET: ${{secrets.DOCKER_SECRET}}
-      DOCKER_REPO: ${{secrets.DOCKER_REPO}}
-    if: needs.pingtest.outputs.pingtest_status == 'success'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run hython tests
-        run: pytest tests/hython/
+#  hython_test:
+#    needs: pingtest
+#    runs-on: ubuntu-latest
+#    env:
+#      DOCKER_USER: ${{secrets.DOCKER_USER}}
+#      DOCKER_SECRET: ${{secrets.DOCKER_SECRET}}
+#      DOCKER_REPO: ${{secrets.DOCKER_REPO}}
+#    if: needs.pingtest.outputs.pingtest_status == 'success'
+#    steps:
+#      - name: Check out repository
+#        uses: actions/checkout@v4
+#
+#      - name: Set up Python
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: 3.11
+#
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install -r requirements.txt
+#
+#      - name: Run hython tests
+#        run: pytest tests/hython/

--- a/.github/workflows/houdocker_autobuild.yml
+++ b/.github/workflows/houdocker_autobuild.yml
@@ -15,27 +15,27 @@ jobs:
       DOCKER_SECRET: ${{secrets.DOCKER_SECRET}}
       DOCKER_REPO: ${{secrets.DOCKER_REPO}}
     steps:
-    - name: Create additional disk space
-      run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Create additional disk space
+        run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-    - name: Check out repository
-      uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ./hbuild/requirements.txt
-    - name: Run autobuild.py
-      id: autobuild
-      run: |
-        export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-        export DOCKER_DEFAULT_PLATFORM="linux/amd64"
-        python ./hbuild/autobuild.py
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./hbuild/requirements.txt
+      - name: Run autobuild.py
+        id: autobuild
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+          export DOCKER_DEFAULT_PLATFORM="linux/amd64"
+          python ./hbuild/autobuild.py
     outputs:
       test_status: ${{ steps.autobuild.outputs.test_status }}
 
@@ -47,19 +47,48 @@ jobs:
       DOCKER_SECRET: ${{secrets.DOCKER_SECRET}}
       DOCKER_REPO: ${{secrets.DOCKER_REPO}}
     if: needs.autobuild.outputs.test_status == 'cont'
+    outputs:
+      pingtest_status: ${{ steps.pingtest.outputs.status }}
     steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-    - name: Run tests
-      run: pytest tests/build/
+      - name: Run tests
+        run: |
+          pytest tests/build/
+          echo "status=success" >> $GITHUB_OUTPUT
+
+  hython_test:
+    needs: pingtest
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_USER: ${{secrets.DOCKER_USER}}
+      DOCKER_SECRET: ${{secrets.DOCKER_SECRET}}
+      DOCKER_REPO: ${{secrets.DOCKER_REPO}}
+    if: needs.pingtest.outputs.pingtest_status == 'success'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run hython tests
+        run: pytest tests/hython/

--- a/hinstall/Dockerfile
+++ b/hinstall/Dockerfile
@@ -55,24 +55,11 @@ RUN rm -r /houdiniInstaller
 FROM debian:12-slim
 COPY --from=houdini-install / /
 
-# OpenCL installation
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ocl-icd-libopencl1 ocl-icd-opencl-dev clinfo mesa-opencl-icd pocl-opencl-icd opencl-headers \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /etc/OpenCL/vendors && echo "libpocl.so" > /etc/OpenCL/vendors/pocl.icd \
+# Add houdini bins to path env variable
+ENV PATH="${PATH}:/opt/houdini/build/houdini/sbin:/opt/houdini/build/bin"
 
-RUN clinfo
-
-ARG OCL_VENDOR=POCL
-ARG OCL_DEVICE_NUMBER=0
-ARG OCL_DEVICE_TYPE=CPU
-
-# OpenCL env variables for Houdini
-ENV PATH="${PATH}:/opt/houdini/build/houdini/sbin:/opt/houdini/build/bin" \
-    HOUDINI_OCL_VENDOR=${OCL_VENDOR} \
-    HOUDINI_OCL_DEVICENUMBER=${OCL_DEVICE_NUMBER} \
-    HOUDINI_OCL_DEVICETYPE=${OCL_DEVICE_TYPE} \
-    OCL_ICD_VENDORS="/etc/OpenCL/vendors"
+ENV HOUDINI_OCL_DEVICENUMBER=0
+ENV HOUDINI_OCL_DEVICETYPE=CPU
 
 # Xvfb headless operation env variables
 ENV DISPLAY=:99

--- a/hinstall/Dockerfile
+++ b/hinstall/Dockerfile
@@ -14,7 +14,7 @@ ENV PYTHONPATH=/code
 RUN mkdir /houdini
 RUN python3 hinstall/houinstall.py
 
-# SECOND STAGE: Install and initialize Houdini
+# SECOND STAGE: Install Houdini
 FROM debian:12-slim as houdini-install
 
 # Update and install required packages
@@ -33,14 +33,14 @@ RUN apt-get update && \
     libnss3 libpci3 libasound2 \
     bc wget \
     libqt5core5a libqt5gui5 libqt5widgets5 libqt5x11extras5 \
-    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
-    libxcb-xinerama0 \
     x11-utils x11-xserver-utils \
     libgl1-mesa-dev libglu1-mesa-dev \
     libgomp1 libglvnd0 \
-    xvfb && \
+    xvfb \
+    ca-certificates && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    update-ca-certificates
 
 COPY --from=houdini-downloader /houdini /houdiniInstaller
 # Please update the following EULA_DATE to match the latest updated
@@ -51,30 +51,28 @@ ARG EULA_DATE="2021-10-13"
 RUN yes | /houdiniInstaller/build/houdini.install --auto-install --accept-EULA ${EULA_DATE} --make-dir /opt/houdini/build
 RUN rm -r /houdiniInstaller
 
-# THIRD STAGE: Copy houdini-install image and un-cache unnecessary installation files
+# THIRD STAGE: Final image
 FROM debian:12-slim
 COPY --from=houdini-install / /
 
-RUN apt-get update && apt-get install -y ca-certificates
-RUN update-ca-certificates
-
 # OpenCL installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev \
-    clinfo \
-    mesa-opencl-icd \
-    pocl-opencl-icd \
-    opencl-headers \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /etc/OpenCL/vendors && \
-    echo "libpocl.so" > /etc/OpenCL/vendors/pocl.icd
+    ocl-icd-libopencl1 ocl-icd-opencl-dev clinfo mesa-opencl-icd pocl-opencl-icd opencl-headers \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /etc/OpenCL/vendors && echo "libpocl.so" > /etc/OpenCL/vendors/pocl.icd \
 
 RUN clinfo
-ENV OCL_ICD_VENDORS="/etc/OpenCL/vendors"
 
-# Final environment assignments
-ENV PATH="${PATH}:/opt/houdini/build/houdini/sbin:/opt/houdini/build/bin"
-ENV HOUDINI_OCL_DEVICETYPE="CPU"
+ARG OCL_VENDOR=POCL
+ARG OCL_DEVICE_NUMBER=0
+ARG OCL_DEVICE_TYPE=CPU
+
+# OpenCL env variables for Houdini
+ENV PATH="${PATH}:/opt/houdini/build/houdini/sbin:/opt/houdini/build/bin" \
+    HOUDINI_OCL_VENDOR=${OCL_VENDOR} \
+    HOUDINI_OCL_DEVICENUMBER=${OCL_DEVICE_NUMBER} \
+    HOUDINI_OCL_DEVICETYPE=${OCL_DEVICE_TYPE} \
+    OCL_ICD_VENDORS="/etc/OpenCL/vendors"
+
+# Xvfb headless operation env variables
 ENV DISPLAY=:99

--- a/hinstall/Dockerfile
+++ b/hinstall/Dockerfile
@@ -15,16 +15,30 @@ RUN mkdir /houdini
 RUN python3 hinstall/houinstall.py
 
 # SECOND STAGE: Install and initialize Houdini
-FROM debian:11-slim as houdini-install
+FROM debian:12-slim as houdini-install
 
 # Update and install required packages
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends iputils-ping netcat inetutils-telnet inetutils-ftp procps && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && \
-    apt-get install -y libglu1 libsm6 bc wget libnss3 libxcomposite1 libxrender1 libxrandr2 libfontconfig1 libxcursor1 libxi6 libxtst6 libxkbcommon0 libxss1 libpci3 libasound2 && \
+    apt-get install -y --no-install-recommends \
+    iputils-ping netcat-openbsd inetutils-telnet inetutils-ftp procps \
+    libgl1 libglu1 libglx0 \
+    libice6 libsm6 \
+    libx11-6 libx11-xcb1 \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb1 \
+    libxcomposite1 libxrender1 libxrandr2 libxcursor1 libxi6 libxtst6 \
+    libxdamage1 libxext6 \
+    libxss1 \
+    libxkbcommon0 libxkbcommon-x11-0 \
+    libfontconfig1 \
+    libnss3 libpci3 libasound2 \
+    bc wget \
+    libqt5core5a libqt5gui5 libqt5widgets5 libqt5x11extras5 \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
+    libxcb-xinerama0 \
+    x11-utils x11-xserver-utils \
+    libgl1-mesa-dev libglu1-mesa-dev \
+    libgomp1 libglvnd0 \
+    xvfb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -38,6 +52,29 @@ RUN yes | /houdiniInstaller/build/houdini.install --auto-install --accept-EULA $
 RUN rm -r /houdiniInstaller
 
 # THIRD STAGE: Copy houdini-install image and un-cache unnecessary installation files
-FROM debian:11-slim
+FROM debian:12-slim
 COPY --from=houdini-install / /
+
+RUN apt-get update && apt-get install -y ca-certificates
+RUN update-ca-certificates
+
+# OpenCL installation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ocl-icd-libopencl1 \
+    ocl-icd-opencl-dev \
+    clinfo \
+    mesa-opencl-icd \
+    pocl-opencl-icd \
+    opencl-headers \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libpocl.so" > /etc/OpenCL/vendors/pocl.icd
+
+RUN clinfo
+ENV OCL_ICD_VENDORS="/etc/OpenCL/vendors"
+
+# Final environment assignments
 ENV PATH="${PATH}:/opt/houdini/build/houdini/sbin:/opt/houdini/build/bin"
+ENV HOUDINI_OCL_DEVICETYPE="CPU"
+ENV DISPLAY=:99

--- a/hinstall/README.md
+++ b/hinstall/README.md
@@ -32,8 +32,9 @@ Once you have started the Docker container using Hbuild, you can quickly get sta
 You can optionally allow these services to access to your [*SideFX API credentials*](https://www.sidefx.com/oauth2/applications/).
 
 ```shell
-hserver -C -S https://www.sidefx.com/license/sesinetd --clientid $SIDEFX_CLIENT --clientsecret $SIDEFX_SECRET
-sesictrl ping --client-id $SIDEFX_CLIENT --client-secret $SIDEFX_SECRET
+hserver --clientid $SIDEFX_CLIENT --clientsecret $SIDEFX_SECRET --host "https://www.sidefx.com/license/sesinetd"
+sesictrl login
+sesictrl ping
 ```
 
 If the request is successful, you should eventually see a response indicating the length of time taken to get a response from the license server (Hserver may initially need to restart itself in order to update the credentials).

--- a/tests/hython/test_hython_init.py
+++ b/tests/hython/test_hython_init.py
@@ -1,13 +1,14 @@
-import pytest
-import docker
 import os
 
-SIDEFX_CLIENT = os.environ.get('SIDEFX_CLIENT')
-SIDEFX_SECRET = os.environ.get('SIDEFX_SECRET')
+import docker
+import pytest
 
-DOCKER_USER = os.environ.get('DOCKER_USER')
-DOCKER_SECRET = os.environ.get('DOCKER_SECRET')
-DOCKER_REPO = os.environ.get('DOCKER_REPO')
+SIDEFX_CLIENT = os.environ.get("SIDEFX_CLIENT")
+SIDEFX_SECRET = os.environ.get("SIDEFX_SECRET")
+
+DOCKER_USER = os.environ.get("DOCKER_USER")
+DOCKER_SECRET = os.environ.get("DOCKER_SECRET")
+DOCKER_REPO = os.environ.get("DOCKER_REPO")
 
 build_repo = f"{DOCKER_USER}/{DOCKER_REPO}"
 build_tag = "latest"
@@ -34,13 +35,10 @@ def test_hython_environment(docker_client):
     log = docker_client.containers.run(
         image=f"{build_repo}:{build_tag}",
         command=command,
-        environment={
-            "SIDEFX_CLIENT": SIDEFX_CLIENT,
-            "SIDEFX_SECRET": SIDEFX_SECRET
-        }
+        environment={"SIDEFX_CLIENT": SIDEFX_CLIENT, "SIDEFX_SECRET": SIDEFX_SECRET},
     )
 
-    log_output = log.decode('utf-8')
+    log_output = log.decode("utf-8")
     # print(log_output)
 
     assert success_message in log_output

--- a/tests/hython/test_hython_init.py
+++ b/tests/hython/test_hython_init.py
@@ -1,0 +1,47 @@
+import pytest
+import docker
+import os
+
+SIDEFX_CLIENT = os.environ.get('SIDEFX_CLIENT')
+SIDEFX_SECRET = os.environ.get('SIDEFX_SECRET')
+
+DOCKER_USER = os.environ.get('DOCKER_USER')
+DOCKER_SECRET = os.environ.get('DOCKER_SECRET')
+DOCKER_REPO = os.environ.get('DOCKER_REPO')
+
+build_repo = f"{DOCKER_USER}/{DOCKER_REPO}"
+build_tag = "latest"
+
+
+@pytest.fixture(scope="module")
+def docker_client():
+    return docker.from_env()
+
+
+def test_hython_environment(docker_client):
+    """
+    Test Hython environment setup and license acquisition.
+    """
+    success_message = "Hython test successful"
+
+    command = f"""
+    /bin/sh -c "
+    hserver --clientid '{SIDEFX_CLIENT}' --clientsecret '{SIDEFX_SECRET}' --host 'https://www.sidefx.com/license/sesinetd' &&
+    sesictrl login &&
+    echo 'print(\"{success_message}\")' | hython"
+    """
+
+    log = docker_client.containers.run(
+        image=f"{build_repo}:{build_tag}",
+        command=command,
+        environment={
+            "SIDEFX_CLIENT": SIDEFX_CLIENT,
+            "SIDEFX_SECRET": SIDEFX_SECRET
+        }
+    )
+
+    log_output = log.decode('utf-8')
+    # print(log_output)
+
+    assert success_message in log_output
+    # assert "OpenCL Exception" not in log_output


### PR DESCRIPTION
Added necessary fixes and updates for standard operating (without OpenCL support) of 20.5

- Updated to Debian 12
- Added Houdini 20.5 libs
- Added X11, Qt5 libs, Certificate updating for future-proofing
- Bundled Xvfb for running Houdini with a virtual frame buffer, with default env variable `DISPLAY=:99`
- Added CPU-only OpenCL environment variables for Houdini (broken with 20.5, as there is a POCL version mismatch by default)
- Added (unused) Hython run test for GitHub workflows